### PR TITLE
fix: Fix to report on struct

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -42,20 +42,20 @@ func run(pass *analysis.Pass) (any, error) {
 		var st *structType
 		st, ok = structs[recv.Name]
 		if !ok {
-			structs[recv.Name] = &structType{recv: recv, starMethods: []*ast.FuncDecl{}, typeMethods: []*ast.FuncDecl{}}
+			structs[recv.Name] = &structType{recv: recv.Name}
 			st = structs[recv.Name]
 		}
 
 		if isStar {
-			st.starMethods = append(st.starMethods, funcDecl)
+			st.numStarMethod++
 		} else {
-			st.typeMethods = append(st.typeMethods, funcDecl)
+			st.numTypeMethod++
 		}
 	})
 
 	for _, st := range structs {
-		if len(st.starMethods) > 0 && len(st.typeMethods) > 0 {
-			pass.Reportf(pass.Pkg.Scope().Lookup(st.recv.Name).Pos(), "the methods of %q use pointer receiver and non pointer receiver.", st.recv.Name)
+		if st.numStarMethod > 0 && st.numTypeMethod > 0 {
+			pass.Reportf(pass.Pkg.Scope().Lookup(st.recv).Pos(), "the methods of %q use pointer receiver and non pointer receiver.", st.recv)
 		}
 	}
 
@@ -63,7 +63,7 @@ func run(pass *analysis.Pass) (any, error) {
 }
 
 type structType struct {
-	recv        *ast.Ident
-	starMethods []*ast.FuncDecl
-	typeMethods []*ast.FuncDecl
+	recv          string
+	numStarMethod int
+	numTypeMethod int
 }

--- a/analyzer.go
+++ b/analyzer.go
@@ -42,7 +42,7 @@ func run(pass *analysis.Pass) (any, error) {
 		var st *structType
 		st, ok = structs[recv.Name]
 		if !ok {
-			structs[recv.Name] = &structType{starMethods: []*ast.FuncDecl{}, typeMethods: []*ast.FuncDecl{}}
+			structs[recv.Name] = &structType{recv: recv, starMethods: []*ast.FuncDecl{}, typeMethods: []*ast.FuncDecl{}}
 			st = structs[recv.Name]
 		}
 
@@ -55,9 +55,7 @@ func run(pass *analysis.Pass) (any, error) {
 
 	for _, st := range structs {
 		if len(st.starMethods) > 0 && len(st.typeMethods) > 0 {
-			for _, typeMethod := range st.typeMethods {
-				pass.Reportf(typeMethod.Pos(), "receiver type should be a pointer")
-			}
+			pass.Reportf(pass.Pkg.Scope().Lookup(st.recv.Name).Pos(), "the methods of %q use pointer receiver and non pointer receiver.", st.recv.Name)
 		}
 	}
 
@@ -65,6 +63,7 @@ func run(pass *analysis.Pass) (any, error) {
 }
 
 type structType struct {
+	recv        *ast.Ident
 	starMethods []*ast.FuncDecl
 	typeMethods []*ast.FuncDecl
 }

--- a/analyzer.go
+++ b/analyzer.go
@@ -55,7 +55,7 @@ func run(pass *analysis.Pass) (any, error) {
 
 	for _, st := range structs {
 		if st.numStarMethod > 0 && st.numTypeMethod > 0 {
-			pass.Reportf(pass.Pkg.Scope().Lookup(st.recv).Pos(), "the methods of %q use pointer receiver and non pointer receiver.", st.recv)
+			pass.Reportf(pass.Pkg.Scope().Lookup(st.recv).Pos(), "the methods of %q use pointer receiver and non-pointer receiver.", st.recv)
 		}
 	}
 

--- a/testdata/src/test/rpc.go
+++ b/testdata/src/test/rpc.go
@@ -4,7 +4,7 @@ import (
 	"time"
 )
 
-type RPC struct { // want `the methods of "RPC" use pointer receiver and non pointer receiver.`
+type RPC struct { // want `the methods of "RPC" use pointer receiver and non-pointer receiver.`
 	result int
 	done   chan struct{}
 }

--- a/testdata/src/test/rpc.go
+++ b/testdata/src/test/rpc.go
@@ -4,7 +4,7 @@ import (
 	"time"
 )
 
-type RPC struct {
+type RPC struct { // want `the methods of "RPC" use pointer receiver and non pointer receiver.`
 	result int
 	done   chan struct{}
 }
@@ -15,6 +15,6 @@ func (rpc *RPC) compute() {
 	close(rpc.done)
 }
 
-func (RPC) version() int { // want "receiver type should be a pointer"
+func (RPC) version() int {
 	return 1 // never going to need to change this
 }

--- a/testdata/src/test/rpc.go
+++ b/testdata/src/test/rpc.go
@@ -18,3 +18,16 @@ func (rpc *RPC) compute() {
 func (RPC) version() int {
 	return 1 // never going to need to change this
 }
+
+// Following main function cause data race error
+// reference: https://dave.cheney.net/2015/11/18/wednesday-pop-quiz-spot-the-race
+// func main() {
+// 	rpc := &RPC{done: make(chan struct{})}
+//
+// 	go rpc.compute()         // kick off computation in the background
+// 	version := rpc.version() // grab some other information while we're waiting
+// 	<-rpc.done               // wait for computation to finish
+// 	result := rpc.result
+//
+// 	fmt.Printf("RPC computation complete, result: %d, version: %d\n", result, version)
+// }


### PR DESCRIPTION
Motivated by https://github.com/golangci/golangci-lint/pull/5013#issuecomment-2350444842

This PR does 
- Fix to report on struct not on method
- Remove recommendation of a pointer receiver by default.

cc @ldez 