### PR TITLE
feat: add SuggestedFixes for --fix support

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -1,6 +1,7 @@
 package recvcheck
 
 import (
+	"fmt"
 	"go/ast"
 
 	"golang.org/x/tools/go/analysis"
@@ -88,12 +89,28 @@ func (r *analyzer) run(pass *analysis.Pass) (any, error) {
 			st.starUsed = true
 		} else {
 			st.typeUsed = true
+			st.valueRecvTypes = append(st.valueRecvTypes, recv)
 		}
 	})
 
 	for recv, st := range structs {
 		if st.starUsed && st.typeUsed {
-			pass.Reportf(pass.Pkg.Scope().Lookup(recv).Pos(), "the methods of %q use pointer receiver and non-pointer receiver.", recv)
+			edits := make([]analysis.TextEdit, len(st.valueRecvTypes))
+			for i, ident := range st.valueRecvTypes {
+				edits[i] = analysis.TextEdit{
+					Pos:     ident.Pos(),
+					End:     ident.Pos(),
+					NewText: []byte("*"),
+				}
+			}
+			pass.Report(analysis.Diagnostic{
+				Pos:     pass.Pkg.Scope().Lookup(recv).Pos(),
+				Message: fmt.Sprintf("the methods of %q use pointer receiver and non-pointer receiver.", recv),
+				SuggestedFixes: []analysis.SuggestedFix{{
+					Message:   fmt.Sprintf("use pointer receiver for %q", recv),
+					TextEdits: edits,
+				}},
+			})
 		}
 	}
 
@@ -116,8 +133,9 @@ func (r *analyzer) isExcluded(recv *ast.Ident, f *ast.FuncDecl) bool {
 }
 
 type structType struct {
-	starUsed bool
-	typeUsed bool
+	starUsed       bool
+	typeUsed       bool
+	valueRecvTypes []*ast.Ident
 }
 
 func recvTypeIdent(r ast.Expr) (*ast.Ident, bool) {

--- a/analyzer.go
+++ b/analyzer.go
@@ -88,13 +88,12 @@ func (r *analyzer) run(pass *analysis.Pass) (any, error) {
 		if isStar {
 			st.starUsed = true
 		} else {
-			st.typeUsed = true
 			st.valueRecvTypes = append(st.valueRecvTypes, recv)
 		}
 	})
 
 	for recv, st := range structs {
-		if st.starUsed && st.typeUsed {
+		if st.starUsed && len(st.valueRecvTypes) > 0 {
 			edits := make([]analysis.TextEdit, len(st.valueRecvTypes))
 			for i, ident := range st.valueRecvTypes {
 				edits[i] = analysis.TextEdit{
@@ -134,7 +133,6 @@ func (r *analyzer) isExcluded(recv *ast.Ident, f *ast.FuncDecl) bool {
 
 type structType struct {
 	starUsed       bool
-	typeUsed       bool
 	valueRecvTypes []*ast.Ident
 }
 

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -38,7 +38,7 @@ func TestAnalyzer(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			a := recvcheck.NewAnalyzer(test.settings)
 
-			analysistest.Run(t, analysistest.TestData(), a, test.desc)
+			analysistest.RunWithSuggestedFixes(t, analysistest.TestData(), a, test.desc)
 		})
 	}
 }

--- a/testdata/src/basic/rpc.go.golden
+++ b/testdata/src/basic/rpc.go.golden
@@ -1,0 +1,33 @@
+package basic
+
+import (
+	"time"
+)
+
+type RPC struct { // want `the methods of "RPC" use pointer receiver and non-pointer receiver.`
+	result int
+	done   chan struct{}
+}
+
+func (rpc *RPC) compute() {
+	time.Sleep(time.Second) // strenuous computation intensifies
+	rpc.result = 42
+	close(rpc.done)
+}
+
+func (*RPC) version() int {
+	return 1 // never going to need to change this
+}
+
+// Following main function cause data race error
+// reference: https://dave.cheney.net/2015/11/18/wednesday-pop-quiz-spot-the-race
+// func main() {
+// 	rpc := &RPC{done: make(chan struct{})}
+//
+// 	go rpc.compute()         // kick off computation in the background
+// 	version := rpc.version() // grab some other information while we're waiting
+// 	<-rpc.done               // wait for computation to finish
+// 	result := rpc.result
+//
+// 	fmt.Printf("RPC computation complete, result: %d, version: %d\n", result, version)
+// }

--- a/testdata/src/disablebuiltin/binary.go.golden
+++ b/testdata/src/disablebuiltin/binary.go.golden
@@ -1,0 +1,11 @@
+package disablebuiltin
+
+type Binary struct{} // want `the methods of "Binary" use pointer receiver and non-pointer receiver.`
+
+func (b *Binary) MarshalBinary() ([]byte, error) {
+	panic("not implemented")
+}
+
+func (b *Binary) UnmarshalBinary(data []byte) error {
+	panic("not implemented")
+}

--- a/testdata/src/disablebuiltin/gob.go.golden
+++ b/testdata/src/disablebuiltin/gob.go.golden
@@ -1,0 +1,11 @@
+package disablebuiltin
+
+type Gob struct{} // want `the methods of "Gob" use pointer receiver and non-pointer receiver.`
+
+func (g *Gob) GobEncode() ([]byte, error) {
+	panic("not implemented")
+}
+
+func (g *Gob) GobDecode(data []byte) error {
+	panic("not implemented")
+}

--- a/testdata/src/disablebuiltin/json.go.golden
+++ b/testdata/src/disablebuiltin/json.go.golden
@@ -1,0 +1,11 @@
+package disablebuiltin
+
+type JSON struct{} // want `the methods of "JSON" use pointer receiver and non-pointer receiver.`
+
+func (j *JSON) MarshalJSON() ([]byte, error) {
+	panic("not implemented")
+}
+
+func (j *JSON) UnmarshalJSON(b []byte) error {
+	panic("not implemented")
+}

--- a/testdata/src/disablebuiltin/text.go.golden
+++ b/testdata/src/disablebuiltin/text.go.golden
@@ -1,0 +1,11 @@
+package disablebuiltin
+
+type Text struct{} // want `the methods of "Text" use pointer receiver and non-pointer receiver.`
+
+func (t *Text) MarshalText() ([]byte, error) {
+	panic("not implemented")
+}
+
+func (t *Text) UnmarshalText(b []byte) error {
+	panic("not implemented")
+}

--- a/testdata/src/disablebuiltin/xml.go.golden
+++ b/testdata/src/disablebuiltin/xml.go.golden
@@ -1,0 +1,13 @@
+package disablebuiltin
+
+import "encoding/xml"
+
+type XML struct{} // want `the methods of "XML" use pointer receiver and non-pointer receiver.`
+
+func (x *XML) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	panic("not implemented")
+}
+
+func (x *XML) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	panic("not implemented")
+}

--- a/testdata/src/disablebuiltin/yaml.go.golden
+++ b/testdata/src/disablebuiltin/yaml.go.golden
@@ -1,0 +1,13 @@
+package disablebuiltin
+
+type Node struct{}
+
+type YAML struct{} // want `the methods of "YAML" use pointer receiver and non-pointer receiver.`
+
+func (j *YAML) MarshalYAML() (any, error) {
+	panic("not implemented")
+}
+
+func (j *YAML) UnmarshalYAML(value *Node) error {
+	panic("not implemented")
+}


### PR DESCRIPTION
## Why

golangci-lint supports `--fix` to auto-fix linter issues, but recvcheck only reports diagnostics without suggested fixes. Users have to manually change value receivers to pointer receivers.

## What

Attach `analysis.SuggestedFix` with `TextEdit`s that insert `*` before value receiver type names. When `golangci-lint --fix` is used, value receivers are automatically converted to pointer receivers.

## Changes

- Switch `pass.Reportf` → `pass.Report(analysis.Diagnostic{...})` with `SuggestedFixes`
- Track value receiver `*ast.Ident` positions during AST walk
- Switch tests to `analysistest.RunWithSuggestedFixes` with `.go.golden` files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Analyzer now provides automatic suggested fixes to convert non-pointer method receivers to pointer receivers, with text edits applied at the identifier positions.

* **Tests**
  * Updated test harness to verify suggested fixes alongside diagnostics.
  * Added comprehensive test fixtures covering various serialization patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->