### PR TITLE
ci: add tag-triggered release workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,6 +3,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_call:
 
 permissions: {}
 
@@ -29,7 +30,7 @@ jobs:
       - run: make build
       - run: make test
       - uses: shogo82148/actions-goveralls@8781f5dd05b691c4dd042d5e859c11c73e0104fa # v1.11.1
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         with:
           path-to-profile: coverage.txt
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,23 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+permissions: {}
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yaml
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --generate-notes


### PR DESCRIPTION
Releases are currently cut by hand: `git tag`, `git push`, then `gh release create --generate-notes`. This makes pushing a semver tag do the rest.

## Changes

- **`release.yaml`** (new) — on a `v[0-9]+.[0-9]+.[0-9]+` tag push, runs the full build matrix, then creates the GitHub release with auto-generated notes. Same note format as v0.3.0.
- **`build.yaml`** — added `workflow_call:` so the release reuses the existing matrix instead of duplicating it.
- **`build.yaml`** — coveralls upload now requires `push` on `refs/heads/main`. `github.event_name != 'pull_request'` is also true inside a `workflow_call` from a tag push, which would upload a duplicate coverage report on every release.

## Notes

The tag filter is strict semver rather than `v*`, so stray tags (`v2-backup`, `vtest`, `v0.4`) can't publish a release. Prereleases like `v0.4.0-rc1` are excluded too; add a second pattern if that's ever wanted.

`gh release create` in a run step rather than an action: the official `actions/create-release` has been archived since 2021 and its README redirects to third-party actions, `gh` ships preinstalled on the runners, and zizmor flags `softprops/action-gh-release` as `superfluous-actions`. No pinned dependency for dependabot to bump.

The `needs: build` gate guards against tagging a commit that isn't on green main. It can't do more than that — by the time the workflow starts the tag is public and the module proxy will serve it, so a bad release still needs `retract` plus a new tag.

Releasing becomes:

```
git tag v0.4.0 && git push origin v0.4.0
```